### PR TITLE
Re-fix fetching weekly publisher logs

### DIFF
--- a/src/app/services/logs-service.tsx
+++ b/src/app/services/logs-service.tsx
@@ -270,8 +270,11 @@ export async function fetchLysPublisherLogs(): Promise<LogsByProcess> {
             // sunday)
             if (Object.keys(logsByPublisher).filter(p => p.includes("weekly")).length < 3) {
                 const lastSunday = new Date();
-                if (lastSunday.getDay() != 0 || lastSunday.getHours() <= 17) {
+                lastSunday.setDate(lastSunday.getDate() + 1);
+                if (lastSunday.getDay() != 0) {
                     lastSunday.setDate(lastSunday.getDate() - lastSunday.getDay());
+                } else if (lastSunday.getHours() <= 17) {
+                    lastSunday.setDate(lastSunday.getDate() - 7);
                 }
                 return fetchLysPublisherLogsForDateAndMode(lastSunday, "weekly").then(weeklyPublisherLogs => {
                     return Object.assign(logsByPublisher, weeklyPublisherLogs);


### PR DESCRIPTION
Turns out, removing 0 from a number gives... the same number.